### PR TITLE
LPS-31808

### DIFF
--- a/portlets/calendar-portlet/docroot/WEB-INF/src/custom-sql/default.xml
+++ b/portlets/calendar-portlet/docroot/WEB-INF/src/custom-sql/default.xml
@@ -34,7 +34,6 @@
 					(startTime >= ?)
 				) AND
 				(firstReminder > 0) AND
-				(secondReminder > 0) AND
 				(status = 0)
 		]]>
 	</sql>


### PR DESCRIPTION
If only one reminder is set, it is always set as the firstReminder so we don't need to check secondReminder.
