### PR TITLE
LPS-31798 Fixes enterprise calendar busy-day-triangle firefox issue

### DIFF
--- a/portlets/calendar-portlet/docroot/css/main.css
+++ b/portlets/calendar-portlet/docroot/css/main.css
@@ -414,6 +414,16 @@
 	}
 }
 
+.firefox .yui3-skin-sam .yui3-calendar-day.lfr-busy-day {
+	background-image: -moz-linear-gradient(top right, #000, #000 12%, transparent 12%, transparent);
+	background-image: linear-gradient(to bottom left, #000, #000 12%, transparent 12%, transparent);
+	background-clip: padding-box;
+
+	&:after {
+		display: none;
+	}
+}
+
 .ie6, .ie7 {
 	.yui3-skin-sam .yui3-calendar-day.lfr-busy-day {
 		background: transparent url(../images/lfr-busy-day-arrow.png) right top no-repeat;


### PR DESCRIPTION
This bug was an instance of https://bugzilla.mozilla.org/show_bug.cgi?id=35168 (and https://bugzilla.mozilla.org/show_bug.cgi?id=63895). It was thus impossible to position the :after element correctly inside the table.
So, instead, for firefox specifically I replaced it with a background gradient that looks the same as the :after. It generates a background-image that is black in the upper-right corner, and transparent everywhere else.
Adding a background-clip statement was required as well, or else the background-image would repeat, appearing as a little bit of black border on the bottom right. Background-clip prevents this repeat, and also prevents the blue :hover background from overlapping the bottom border (notice before this fix that if you hover over a busy day, the blue color goes 1px lower than on non-busy days).
The gradient works on firefox versions since 3.6, and the background-clip works since 4.0. To make background-clip work further back, we could add -moz-background-clip: padding (works since firefox 1.0), but I thought this was unnecessary.
